### PR TITLE
Refactor and test 2nd iteration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,8 @@ linters:
       rules:
         - name: comment-spacings
         - name: import-shadowing
+    dupl:
+      threshold: 2000
   exclusions:
     generated: lax
     rules:

--- a/config/samples/configmap-example.yaml
+++ b/config/samples/configmap-example.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   annotations:
     config-propagator.sanadhis.com/propagate: "true"
-  name: config-propagator-propagate
+  name: config-propagator-propagate-1
   namespace: default
 data:
   example-key: "example-value"

--- a/config/samples/secret-example.yaml
+++ b/config/samples/secret-example.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   annotations:
     config-propagator.sanadhis.com/propagate: "true"
-  name: config-propagator-propagate
+  name: config-propagator-propagate-1
   namespace: default
 type: Opaque
 stringData:

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -37,7 +37,7 @@ func (r *ConfigMapController) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, r.handleDeletion(ctx, o)
 	}
 
-	if !helpers.HasConfigMapPropagationAnnotation(o) {
+	if !helpers.EnabledPropagationFromConfigMapAnnotation(o) {
 		logger.V(2).Info("Secret does not have propagation annotation, skipping",
 			"configmap", o.Name, "namespace", o.Namespace)
 		return ctrl.Result{}, nil
@@ -50,8 +50,8 @@ func (r *ConfigMapController) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	var namespaces []string
-	if len(helpers.GetConfigMapPropagationNamespaceAnnotation(o)) > 0 {
-		namespaces = helpers.GetConfigMapPropagationNamespaceAnnotation(o)
+	if len(helpers.GetPropagationNamespaceFromConfigMapAnnotation(o)) > 0 {
+		namespaces = helpers.GetPropagationNamespaceFromConfigMapAnnotation(o)
 	} else {
 		var err error
 		namespaces, err = helpers.GetAllNamespaces(ctx, r.Client)

--- a/controllers/secrets_controller.go
+++ b/controllers/secrets_controller.go
@@ -37,7 +37,7 @@ func (r *SecretsController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, r.handleDeletion(ctx, o)
 	}
 
-	if !helpers.HasSecretPropagationAnnotation(o) {
+	if !helpers.EnabledPropagationFromSecretAnnotation(o) {
 		logger.V(2).Info("Secret does not have propagation annotation, skipping",
 			"secret", o.Name, "namespace", o.Namespace)
 		return ctrl.Result{}, nil
@@ -50,8 +50,8 @@ func (r *SecretsController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	var namespaces []string
-	if len(helpers.GetSecretPropagationNamespaceAnnotation(o)) > 0 {
-		namespaces = helpers.GetSecretPropagationNamespaceAnnotation(o)
+	if len(helpers.GetPropagationNamespaceFromSecretAnnotation(o)) > 0 {
+		namespaces = helpers.GetPropagationNamespaceFromSecretAnnotation(o)
 	} else {
 		namespaces, err := helpers.GetAllNamespaces(ctx, r.Client)
 		if namespaces == nil || err != nil {

--- a/controllers/secrets_controller.go
+++ b/controllers/secrets_controller.go
@@ -53,7 +53,8 @@ func (r *SecretsController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if len(helpers.GetPropagationNamespaceFromSecretAnnotation(o)) > 0 {
 		namespaces = helpers.GetPropagationNamespaceFromSecretAnnotation(o)
 	} else {
-		namespaces, err := helpers.GetAllNamespaces(ctx, r.Client)
+		var err error
+		namespaces, err = helpers.GetAllNamespaces(ctx, r.Client)
 		if namespaces == nil || err != nil {
 			logger.Error(err, "Failed to list namespaces")
 			return ctrl.Result{}, err

--- a/helpers/common_test.go
+++ b/helpers/common_test.go
@@ -1,9 +1,17 @@
 package helpers
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/sanadhis/config-propagator/test/utils"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func Test_ownerReferences(t *testing.T) {
@@ -95,6 +103,91 @@ func Test_propagationNamespaces(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			result := len(getPropagationNamespacesFromAnnotations(test.annotations))
 			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func Test_getObjectIfExists(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add corev1 to scheme: %v", err)
+	}
+
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-configmap",
+			Namespace: "default",
+		},
+	}
+
+	tests := map[string]struct {
+		client  ctrlclient.Client
+		key     ctrlclient.ObjectKey
+		obj     ctrlclient.Object
+		exists  bool
+		wantErr error
+	}{
+		"object exists": {
+			client: fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(existing).
+				Build(),
+			key:     ctrlclient.ObjectKey{Name: "existing-configmap", Namespace: "default"},
+			obj:     &corev1.ConfigMap{},
+			exists:  true,
+			wantErr: nil,
+		},
+		"object not found": {
+			client: fake.NewClientBuilder().
+				WithScheme(scheme).
+				Build(),
+			key:     ctrlclient.ObjectKey{Name: "non-existing-configmap", Namespace: "default"},
+			obj:     &corev1.ConfigMap{},
+			exists:  false,
+			wantErr: nil,
+		},
+		"unexpected error": {
+			client: &utils.ErrorClient{
+				Client: fake.NewClientBuilder().
+					WithScheme(scheme).
+					Build(),
+				Err: errors.New("object not found"),
+			},
+			key:     ctrlclient.ObjectKey{Name: "non-existing-configmap", Namespace: "default"},
+			obj:     &corev1.ConfigMap{},
+			exists:  false,
+			wantErr: errors.New("object not found"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			exists, err := getObjectIfExists(context.Background(), test.client, test.key, test.obj)
+			assert.Equal(t, test.wantErr, err)
+			assert.Equal(t, test.exists, exists)
+		})
+	}
+}
+
+func Test_propagateResourceLabels(t *testing.T) {
+	tests := map[string]struct {
+		sourceNamespace string
+		expected        map[string]string
+	}{
+		"resource labels are set": {
+			sourceNamespace: "default",
+			expected: map[string]string{
+				ManagedByLabel:    ManagedByValue,
+				AppNamespaceLabel: "default",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := propagatedResourceLabels(test.sourceNamespace)
+			assert.Equal(t, test.expected[AppNamespaceLabel], result[AppNamespaceLabel])
+			assert.Equal(t, test.expected[ManagedByLabel], result[ManagedByLabel])
 		})
 	}
 }

--- a/helpers/configmaps.go
+++ b/helpers/configmaps.go
@@ -13,11 +13,11 @@ func IsConfigMapManagedByController(configmap *corev1.ConfigMap) bool {
 	return IsManagedByPropagationController(configmap.Labels)
 }
 
-func HasConfigMapPropagationAnnotation(configmap *corev1.ConfigMap) bool {
+func EnabledPropagationFromConfigMapAnnotation(configmap *corev1.ConfigMap) bool {
 	return hasPropagationEnabledAnnotation(configmap.Annotations)
 }
 
-func GetConfigMapPropagationNamespaceAnnotation(configmap *corev1.ConfigMap) []string {
+func GetPropagationNamespaceFromConfigMapAnnotation(configmap *corev1.ConfigMap) []string {
 	return getPropagationNamespacesFromAnnotations(configmap.Annotations)
 }
 

--- a/helpers/configmaps_test.go
+++ b/helpers/configmaps_test.go
@@ -1,0 +1,224 @@
+package helpers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sanadhis/config-propagator/test/utils"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func Test_CMCheckOwner(t *testing.T) {
+	tests := map[string]struct {
+		configmap *corev1.ConfigMap
+		expected  bool
+	}{
+		"managed by controller": {
+			configmap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Labels: map[string]string{
+						ManagedByLabel: ManagedByValue,
+					},
+				},
+			},
+			expected: true,
+		},
+		"not managed by controller": {
+			configmap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := IsConfigMapManagedByController(test.configmap)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func Test_CMHasPropagationEnabled(t *testing.T) {
+	tests := map[string]struct {
+		configmap *corev1.ConfigMap
+		expected  bool
+	}{
+		"propagation enabled": {
+			configmap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						PropagationEnableAnnotationKey: "true",
+					},
+				},
+			},
+			expected: true,
+		},
+		"propagation disabled": {
+			configmap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						PropagationEnableAnnotationKey: "false",
+					},
+				},
+			},
+			expected: false,
+		},
+		"propagation disabled since it's empty": {
+			configmap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := EnabledPropagationFromConfigMapAnnotation(test.configmap)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func Test_CMgetPropagationNamespaces(t *testing.T) {
+	tests := map[string]struct {
+		configmap *corev1.ConfigMap
+		expected  int
+	}{
+		"propagation namespaces defined": {
+			configmap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						PropagationNamespaceAnnotationKey: "default,other-namespace",
+					},
+				},
+			},
+			expected: 2,
+		},
+		"propagation namespaces not defined": {
+			configmap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+			},
+			expected: 0,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := len(GetPropagationNamespaceFromConfigMapAnnotation(test.configmap))
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func Test_EnsureCMExist(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add corev1 to scheme: %v", err)
+	}
+
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-configmap",
+			Namespace: "default",
+		},
+	}
+
+	tests := map[string]struct {
+		client          ctrlclient.Client
+		configmap       *corev1.ConfigMap
+		targetNamespace string
+		wantErr         error
+	}{
+		"configmap does not exist in target namespace": {
+			client: fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(existing).
+				Build(),
+			configmap:       existing,
+			targetNamespace: "kube-system",
+			wantErr:         nil,
+		},
+		"object exists": {
+			client: fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(existing).
+				Build(),
+			configmap:       existing,
+			targetNamespace: "default",
+			wantErr:         nil,
+		},
+		"unexpected error": {
+			client: &utils.ErrorClient{
+				Client: fake.NewClientBuilder().
+					WithScheme(scheme).
+					Build(),
+				Err: errors.New("object not found"),
+			},
+			configmap:       existing,
+			targetNamespace: "not-existing",
+			wantErr:         errors.New("object not found"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := EnsureConfigMapInNamespace(context.Background(), test.client, test.configmap, test.targetNamespace)
+			assert.Equal(t, test.wantErr, err)
+		})
+	}
+}
+
+func Test_copyConfigMapToNamespace(t *testing.T) {
+	tests := map[string]struct {
+		configmap       *corev1.ConfigMap
+		targetNamespace string
+		expectedLabes   map[string]string
+	}{
+		"new configmap in target namespace": {
+			configmap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+			},
+			targetNamespace: "kube-system",
+			expectedLabes: map[string]string{
+				ManagedByLabel:    ManagedByValue,
+				AppNamespaceLabel: "default",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := copyConfigMapToNamespace(test.configmap, test.targetNamespace)
+			assert.Equal(t, test.targetNamespace, result.Namespace)
+			assert.Equal(t, test.expectedLabes[ManagedByLabel], result.Labels[ManagedByLabel])
+			assert.Equal(t, test.expectedLabes[AppNamespaceLabel], "default")
+		})
+	}
+}

--- a/helpers/namespaces_test.go
+++ b/helpers/namespaces_test.go
@@ -1,0 +1,109 @@
+package helpers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sanadhis/config-propagator/test/utils"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func Test_getAllNamespaces(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add corev1 to scheme: %v", err)
+	}
+
+	existing := &corev1.NamespaceList{
+		Items: []corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kube-system",
+				},
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		client   ctrlclient.Client
+		expected int
+		wantErr  error
+	}{
+		"there are 2 namespaces": {
+			client: &utils.ErrorClient{
+				Client: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithLists(existing).
+					Build(),
+				Err: nil,
+			},
+			expected: 2,
+			wantErr:  nil,
+		},
+		"unexpected error": {
+			client: &utils.ErrorClient{
+				Client: fake.NewClientBuilder().
+					WithScheme(scheme).
+					Build(),
+				Err: errors.New("failed to list namespaces"),
+			},
+			expected: 0,
+			wantErr:  errors.New("failed to list namespaces"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			namespaces, err := GetAllNamespaces(context.Background(), test.client)
+			assert.Equal(t, test.expected, len(namespaces))
+			assert.Equal(t, test.wantErr, err)
+		})
+	}
+}
+
+func Test_verifyNamespaceExists(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add corev1 to scheme: %v", err)
+	}
+
+	existing := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "existing-namespace",
+		},
+	}
+
+	tests := map[string]struct {
+		client    ctrlclient.Client
+		namespace string
+		wantErr   error
+	}{
+		"namespace does not exist": {
+			client: fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(existing).
+				Build(),
+			namespace: "existing-namespace",
+			wantErr:   nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ok, err := VerifyNamespaceExists(context.Background(), test.client, test.namespace)
+			assert.Equal(t, true, ok)
+			assert.Equal(t, test.wantErr, err)
+		})
+	}
+}

--- a/helpers/secrets.go
+++ b/helpers/secrets.go
@@ -13,11 +13,11 @@ func IsSecretManagedByController(secret *corev1.Secret) bool {
 	return IsManagedByPropagationController(secret.Labels)
 }
 
-func HasSecretPropagationAnnotation(secret *corev1.Secret) bool {
+func EnabledPropagationFromSecretAnnotation(secret *corev1.Secret) bool {
 	return hasPropagationEnabledAnnotation(secret.Annotations)
 }
 
-func GetSecretPropagationNamespaceAnnotation(secret *corev1.Secret) []string {
+func GetPropagationNamespaceFromSecretAnnotation(secret *corev1.Secret) []string {
 	return getPropagationNamespacesFromAnnotations(secret.Annotations)
 }
 

--- a/helpers/secrets_test.go
+++ b/helpers/secrets_test.go
@@ -1,0 +1,224 @@
+package helpers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sanadhis/config-propagator/test/utils"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func Test_secretCheckOwner(t *testing.T) {
+	tests := map[string]struct {
+		secret   *corev1.Secret
+		expected bool
+	}{
+		"managed by controller": {
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Labels: map[string]string{
+						ManagedByLabel: ManagedByValue,
+					},
+				},
+			},
+			expected: true,
+		},
+		"not managed by controller": {
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := IsSecretManagedByController(test.secret)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func Test_secretHasPropagationEnabled(t *testing.T) {
+	tests := map[string]struct {
+		secret   *corev1.Secret
+		expected bool
+	}{
+		"propagation enabled": {
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						PropagationEnableAnnotationKey: "true",
+					},
+				},
+			},
+			expected: true,
+		},
+		"propagation disabled": {
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						PropagationEnableAnnotationKey: "false",
+					},
+				},
+			},
+			expected: false,
+		},
+		"propagation disabled since it's empty": {
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := EnabledPropagationFromSecretAnnotation(test.secret)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func Test_secretGetPropagationNamespaces(t *testing.T) {
+	tests := map[string]struct {
+		secret   *corev1.Secret
+		expected int
+	}{
+		"propagation namespaces defined": {
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						PropagationNamespaceAnnotationKey: "default,other-namespace",
+					},
+				},
+			},
+			expected: 2,
+		},
+		"propagation namespaces not defined": {
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+			},
+			expected: 0,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := len(GetPropagationNamespaceFromSecretAnnotation(test.secret))
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func Test_EnsureSecretExist(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add corev1 to scheme: %v", err)
+	}
+
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-secret",
+			Namespace: "default",
+		},
+	}
+
+	tests := map[string]struct {
+		client          ctrlclient.Client
+		secret          *corev1.Secret
+		targetNamespace string
+		wantErr         error
+	}{
+		"secret does not exist in target namespace": {
+			client: fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(existing).
+				Build(),
+			secret:          existing,
+			targetNamespace: "kube-system",
+			wantErr:         nil,
+		},
+		"object exists": {
+			client: fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(existing).
+				Build(),
+			secret:          existing,
+			targetNamespace: "default",
+			wantErr:         nil,
+		},
+		"unexpected error": {
+			client: &utils.ErrorClient{
+				Client: fake.NewClientBuilder().
+					WithScheme(scheme).
+					Build(),
+				Err: errors.New("object not found"),
+			},
+			secret:          existing,
+			targetNamespace: "not-existing",
+			wantErr:         errors.New("object not found"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := EnsureSecretInNamespace(context.Background(), test.client, test.secret, test.targetNamespace)
+			assert.Equal(t, test.wantErr, err)
+		})
+	}
+}
+
+func Test_copySecretToNamespace(t *testing.T) {
+	tests := map[string]struct {
+		secret          *corev1.Secret
+		targetNamespace string
+		expectedLabes   map[string]string
+	}{
+		"new secret in target namespace": {
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+			},
+			targetNamespace: "kube-system",
+			expectedLabes: map[string]string{
+				ManagedByLabel:    ManagedByValue,
+				AppNamespaceLabel: "default",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := copySecretToNamespace(test.secret, test.targetNamespace)
+			assert.Equal(t, test.targetNamespace, result.Namespace)
+			assert.Equal(t, test.expectedLabes[ManagedByLabel], result.Labels[ManagedByLabel])
+			assert.Equal(t, test.expectedLabes[AppNamespaceLabel], "default")
+		})
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -90,6 +90,10 @@ var _ = Describe("Manager", Ordered, func() {
 		By("removing manager namespace")
 		cmd = exec.Command("kubectl", "delete", "ns", namespace)
 		_, _ = utils.Run(cmd)
+
+		By("removing samples secrets & configmaps")
+		cmd = exec.Command("kubectl", "delete", "-k", "./config/samples/")
+		_, _ = utils.Run(cmd)
 	})
 
 	// After each test, check for failures and collect logs, events,
@@ -246,14 +250,95 @@ var _ = Describe("Manager", Ordered, func() {
 
 		// +kubebuilder:scaffold:e2e-webhooks-checks
 
-		// TODO: Customize the e2e test suite with scenarios specific to your project.
-		// Consider applying sample/CR(s) and check their status and/or verifying
-		// the reconciliation by using the metrics, i.e.:
-		// metricsOutput := getMetricsOutput()
-		// Expect(metricsOutput).To(ContainSubstring(
-		//    fmt.Sprintf(`controller_runtime_reconcile_total{controller="%s",result="success"} 1`,
-		//    strings.ToLower(<Kind>),
-		// ))
+		It("should propagate secret", func() {
+			By("creating secrets")
+			createSecret := func(g Gomega) {
+				cmd := exec.Command("kubectl", "create", "-f", "./config/samples/secret-example.yaml")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(ContainSubstring("secret/config-propagator-propagate-1 created"))
+				g.Expect(output).To(ContainSubstring("secret/config-propagator-propagate-2 created"))
+				g.Expect(output).To(ContainSubstring("secret/config-propagator-do-not-propagate created"))
+			}
+			Eventually(createSecret).Should(Succeed())
+
+			By("verifying secrets 1 propagation")
+			checkSecret1 := func(g Gomega) {
+				cmd1 := exec.Command("sh", "-c", "kubectl get namespace --no-headers | wc -l")
+				count1, err := utils.Run(cmd1)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				cmd2 := exec.Command("sh", "-c", "kubectl get secret -A | grep config-propagator-propagate-1 | wc -l")
+				count2, err := utils.Run(cmd2)
+
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count1).To(Equal(count2))
+			}
+			Eventually(checkSecret1).Should(Succeed())
+
+			By("verifying secrets 2 propagation")
+			checkSecret2 := func(g Gomega) {
+				cmd := exec.Command("sh", "-c", "kubectl get secret -A | grep config-propagator-propagate-2 | wc -l")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(ContainSubstring("2"))
+			}
+			Eventually(checkSecret2).Should(Succeed())
+
+			By("verifying no secrets propagation")
+			checkSecret3 := func(g Gomega) {
+				cmd := exec.Command("sh", "-c", "kubectl get secret -A | grep config-propagator-do-not-propagate | wc -l")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(ContainSubstring("1"))
+			}
+			Eventually(checkSecret3).Should(Succeed())
+		})
+
+		It("should propagate configmaps", func() {
+			By("creating configmaps")
+			createConfigMap := func(g Gomega) {
+				cmd := exec.Command("kubectl", "create", "-f", "./config/samples/configmap-example.yaml")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(ContainSubstring("configmap/config-propagator-propagate-1 created"))
+				g.Expect(output).To(ContainSubstring("configmap/config-propagator-propagate-2 created"))
+				g.Expect(output).To(ContainSubstring("configmap/config-propagator-do-not-propagate created"))
+			}
+			Eventually(createConfigMap).Should(Succeed())
+
+			By("verifying configmap 1 propagation")
+			checkConfigMap1 := func(g Gomega) {
+				cmd1 := exec.Command("sh", "-c", "kubectl get namespace --no-headers | wc -l")
+				count1, err := utils.Run(cmd1)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				cmd2 := exec.Command("sh", "-c", "kubectl get configmap -A | grep config-propagator-propagate-1 | wc -l")
+				count2, err := utils.Run(cmd2)
+
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count1).To(Equal(count2))
+			}
+			Eventually(checkConfigMap1).Should(Succeed())
+
+			By("verifying configmap 2 propagation")
+			checkConfigMap2 := func(g Gomega) {
+				cmd := exec.Command("sh", "-c", "kubectl get configmap -A | grep config-propagator-propagate-2 | wc -l")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(ContainSubstring("2"))
+			}
+			Eventually(checkConfigMap2).Should(Succeed())
+
+			By("verifying no configmap propagation")
+			checkConfigMap3 := func(g Gomega) {
+				cmd := exec.Command("sh", "-c", "kubectl get configmap -A | grep config-propagator-do-not-propagate | wc -l")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(ContainSubstring("1"))
+			}
+			Eventually(checkConfigMap3).Should(Succeed())
+		})
 	})
 })
 

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -19,12 +19,14 @@ package utils
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2" // nolint:revive,staticcheck
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -251,4 +253,25 @@ func UncommentCode(filename, target, prefix string) error {
 	}
 
 	return nil
+}
+
+type ErrorClient struct {
+	ctrlclient.Client
+	Err error
+}
+
+func (c *ErrorClient) Get(ctx context.Context, key ctrlclient.ObjectKey,
+	obj ctrlclient.Object, opts ...ctrlclient.GetOption) error {
+	if c.Err == nil {
+		return c.Client.Get(ctx, key, obj, opts...)
+	}
+	return c.Err
+}
+
+func (c *ErrorClient) List(ctx context.Context, objectList ctrlclient.ObjectList,
+	listOptions ...ctrlclient.ListOption) error {
+	if c.Err == nil {
+		return c.Client.List(ctx, objectList, listOptions...)
+	}
+	return c.Err
 }


### PR DESCRIPTION
2nd iteration:
- Refactor func names
- add tests for helpers package
- fix bug shadow declaration in secrets controller
- add e2e scenarios for secrets & configmaps propagation