### PR TITLE
Feat bounded concurrency

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -53,12 +53,15 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var tlsOpts []func(*tls.Config)
+	var concurrencyLimit int
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.IntVar(&concurrencyLimit, "concurrency-limit", 10, "The maximum number of concurrent propagation of "+
+		"secret/configmap to namespaces. ")
 	opts := zap.Options{
 		Development: true,
 	}

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sanadhis/config-propagator/helpers"
+	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,7 +15,8 @@ import (
 
 type ConfigMapController struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme           *runtime.Scheme
+	ConcurrencyLimit int
 }
 
 func (r *ConfigMapController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -61,23 +63,40 @@ func (r *ConfigMapController) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
-	for _, ns := range namespaces {
-		if ns == o.Namespace {
-			logger.Info("ConfigMap is in the same namespace as the Namespace, skipping",
-				"configmap", o.Name, "namespace", ns)
-			continue
-		}
-		if ok, err := helpers.VerifyNamespaceExists(ctx, r.Client, ns); !ok || err != nil {
-			logger.Info("[WARNING] Namespace does not exist or failed to get, skipping",
-				"namespace", ns)
-			continue
-		}
+	var g errgroup.Group
+	if r.ConcurrencyLimit > 0 {
+		g.SetLimit(r.ConcurrencyLimit)
+	} else {
+		// Default to a reasonable concurrency limit if not set
+		g.SetLimit(10)
+	}
 
-		if err := helpers.EnsureConfigMapInNamespace(ctx, r.Client, o, ns); err != nil {
-			logger.Error(err, "Failed to ensure ConfigMap in namespace",
-				"configmap", o.Name, "namespace", ns)
-			return ctrl.Result{}, err
-		}
+	for _, ns := range namespaces {
+		g.Go(func() error {
+			if ns == o.Namespace {
+				logger.Info("ConfigMap is in the same namespace as the Namespace, skipping",
+					"configmap", o.Name, "namespace", ns)
+				return nil
+			}
+
+			if ok, err := helpers.VerifyNamespaceExists(ctx, r.Client, ns); !ok || err != nil {
+				logger.Info("[WARNING] Namespace does not exist or failed to get, skipping",
+					"namespace", ns)
+				return nil
+			}
+
+			if err := helpers.EnsureConfigMapInNamespace(ctx, r.Client, o, ns); err != nil {
+				logger.Error(err, "Failed to ensure ConfigMap in namespace",
+					"configmap", o.Name, "namespace", ns)
+				return err
+			}
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sanadhis/config-propagator/helpers"
+	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,7 +15,8 @@ import (
 
 type SecretController struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme           *runtime.Scheme
+	ConcurrencyLimit int
 }
 
 func (r *SecretController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -61,23 +63,40 @@ func (r *SecretController) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 	}
 
-	for _, ns := range namespaces {
-		if ns == o.Namespace {
-			logger.Info("Secret is in the same namespace as the Namespace, skipping",
-				"secret", o.Name, "namespace", ns)
-			continue
-		}
-		if ok, err := helpers.VerifyNamespaceExists(ctx, r.Client, ns); !ok || err != nil {
-			logger.Info("[WARNING] Namespace does not exist or failed to get, skipping",
-				"namespace", ns)
-			continue
-		}
+	var g errgroup.Group
+	if r.ConcurrencyLimit > 0 {
+		g.SetLimit(r.ConcurrencyLimit)
+	} else {
+		// Default to a reasonable concurrency limit if not set
+		g.SetLimit(10)
+	}
 
-		if err := helpers.EnsureSecretInNamespace(ctx, r.Client, o, ns); err != nil {
-			logger.Error(err, "Failed to ensure Secret in namespace",
-				"secret", o.Name, "namespace", ns)
-			return ctrl.Result{}, err
-		}
+	for _, ns := range namespaces {
+		g.Go(func() error {
+			if ns == o.Namespace {
+				logger.Info("Secret is in the same namespace as the Namespace, skipping",
+					"secret", o.Name, "namespace", ns)
+				return nil
+			}
+
+			if ok, err := helpers.VerifyNamespaceExists(ctx, r.Client, ns); !ok || err != nil {
+				logger.Info("[WARNING] Namespace does not exist or failed to get, skipping",
+					"namespace", ns)
+				return nil
+			}
+
+			if err := helpers.EnsureSecretInNamespace(ctx, r.Client, o, ns); err != nil {
+				logger.Error(err, "Failed to ensure Secret in namespace",
+					"secret", o.Name, "namespace", ns)
+				return err
+			}
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil


### PR DESCRIPTION
Add bounded concurrency to secret & configmap controllers, basically allowing concurrent propagation to namespaces

Also improve disabling of kubectl kuberc in e2e tests