### PR TITLE
ci(release): switch completely to PR-based tests

### DIFF
--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -12,18 +12,7 @@ on:
       - 'config/**'
 
 jobs:
-  lint:
-    uses: ./.github/workflows/lint.yml
-
-  tests:
-    uses: ./.github/workflows/test.yml
-
-  e2e:
-    uses: ./.github/workflows/test-e2e.yml
-
   trigger-release:
-    needs: [lint, tests, e2e]
-    if: ${{ success() }}
     name: Trigger Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
There is no need to specify all test workflows in the trigger release workflow since trigger release workflow will produce PR and hence checks can be performed on release PR